### PR TITLE
remove jsxgraph event handlers

### DIFF
--- a/src/components/graph/GraphView.jsx
+++ b/src/components/graph/GraphView.jsx
@@ -106,14 +106,11 @@ const GraphView = () => {
           minorHeight: 3,
         },
       },
-      zoom: { enabled: true, needShift: false },
-      pan: { enabled: true, needShift: false, needTwoFingers: true},
+      zoom: { enabled: false, needShift: false },
+      pan: { enabled: false, needShift: false, needTwoFingers: true},
       showCopyright: false,
-      showNavigation: false, //hides arrows and zoom icons
-      drag: {
-       enabled: false
-      }
-    });
+      showNavigation: false //hides arrows and zoom icons
+      });
 
     board.removeEventHandlers(); // remove all event handlers
     board.addPointerEventHandlers()


### PR DESCRIPTION
Remoce jsxgraph event handlers
Also, jsxgraph navigation symbols are hiddend. This smooths the path to #36 and the strange behavior of using jsxgraph navigation icons and then pressing a key.