### PR TITLE
enable assigning values in function definition

### DIFF
--- a/src/components/graph/GraphView.jsx
+++ b/src/components/graph/GraphView.jsx
@@ -49,34 +49,42 @@ function createEndPoints(func,board){
         return [[],[]];
     }
     const l = parsed.items; //list of items, each item is a pair [expr,ineq]
-    let ineq,v,a,b,p,i;
+    let ineq,v,a,b,p,i,fn;
     const endpoints = []; // the endpoints of the intervals
     for (i=0;i< l.length;i++){
         ineq = transformAssingnments(l[i].items[1]); // the inequality or equality of ith item, we change assignments to equalities
+        fn = l[i].items[0]; // the expression of the function in the ith item 
+        if (fn.type == "AssignmentNode"){ // if it is an assignment, we get the expression of the assignment
+          fn=fn.value;
+        }
+        if (fn.type == "FunctionAssignmentNode"){ // if it is an assignment, we get the expression of the assignment  
+          fn=fn.expr;
+        }
+        console.log("Processing item ", i, " with function: ", fn, " and condition: ", ineq.toString());
         if ("op" in ineq){ //that is a single inequality or an equality
             if (ineq.op == "<=" || ineq.op ==">=" || ineq.op =="=="){ //one of the arguments is the variable "x"
                 if (("name" in ineq.args[1]) && (ineq.args[1].name == "x")){ // we have a op x, with op in {<=, >=, ==}
                     v=ineq.args[0].evaluate(); // v is the value of a in a op x
-                    p=board.create("point", [v,l[i].items[0].evaluate({x:v})], {cssClass: 'endpoint-closed', fixed:true, highlight:false, withLabel:false, size: 4});
+                    p=board.create("point", [v,fn.evaluate({x:v})], {cssClass: 'endpoint-closed', fixed:true, highlight:false, withLabel:false, size: 4});
                     endpoints.push(p);
                     if (ineq.op == "=="){ // if we have an equality, we add the x coordinate to the list of x-coordinates of isolated points
                         // console.log("Adding isolated point at x=", v);
                         func.pointOfInterests.push({
                             x: v,
-                            y: l[i].items[0].evaluate({x:v}),
+                            y: fn.evaluate({x:v}),
                             type: "isolated"
                         });
                         // console.log("Function ", func);
                       }
                 }else{ // we have x op a, with op in {<=, >=, ==}
                     v=ineq.args[1].evaluate(); // v is the value of a in x op a
-                    p=board.create("point", [v,l[i].items[0].evaluate({x:v})], {cssClass: 'isolated-point', fixed:true, highlight:false, withLabel:false, size: 4});
+                    p=board.create("point", [v,fn.evaluate({x:v})], {cssClass: 'isolated-point', fixed:true, highlight:false, withLabel:false, size: 4});
                     endpoints.push(p);
                     if (ineq.op == "=="){ // if we have an equality, we add the x coordinate to the list of x-coordinates of isolated points
                         // console.log("Adding isolated point at x=", v);
                         func.pointOfInterests.push({
                             x: v,
-                            y: l[i].items[0].evaluate({x:v}),
+                            y: fn.evaluate({x:v}),
                             type: "isolated"
                         });
                         // console.log("Function ", func);
@@ -86,10 +94,10 @@ function createEndPoints(func,board){
             if (ineq.op == "<" || ineq.op ==">" || ineq.op=="!="){ // this we fill in white, since it is an strict inequality
                 if (("name" in ineq.args[1]) && (ineq.args[1].name == "x")){ // we have a op x, with op in {<,>}
                     v=ineq.args[0].evaluate(); // v is the value of a in a op x
-                    let fv = l[i].items[0].evaluate({x:v});
+                    let fv = fn.evaluate({x:v});
                     if (ineq.op == "!="){
                       if (isNaN(fv)){// the point is not defined here, we try the mean of the values at the left and right of v
-                        fv=(l[i].items[0].evaluate({x:v-0.0000001})+l[i].items[0].evaluate({x:v+0.0000001})/2);
+                        fv=(fn.evaluate({x:v-0.0000001})+fn.evaluate({x:v+0.0000001})/2);
                       }
                       // console.log("Possible value at x=", v, fv);
                       func.pointOfInterests.push({
@@ -102,10 +110,10 @@ function createEndPoints(func,board){
                     endpoints.push(p);
                 }else{ // we have x op a, with op in {<, >}
                     v=ineq.args[1].evaluate(); // v is the value of a in x op a
-                    let fv = l[i].items[0].evaluate({x:v});
+                    let fv = fn.evaluate({x:v});
                     if (ineq.op == "!="){
                       if (isNaN(fv)){// the point is not defined here, we try the mean of the values at the left and right of v
-                        fv=(l[i].items[0].evaluate({x:v-0.0000001})+l[i].items[0].evaluate({x:v+0.0000001})/2);
+                        fv=(fn.evaluate({x:v-0.0000001})+fn.evaluate({x:v+0.0000001})/2);
                       }
                       // console.log("Possible value at x=", v, fv);
                       func.pointOfInterests.push({
@@ -124,17 +132,17 @@ function createEndPoints(func,board){
             b=ineq.params[2].evaluate(); // the value of b in a op x op b
             // we should check here that conditionals are in the form smaller, smallerEq
             if (ineq.conditionals[0]=="smaller"){ // this is a smaller so we fill in white, since it is an strict inequality
-                p=board.create("point", [a,l[i].items[0].evaluate({x:a})], {cssClass: 'endpoint-open', fixed:true, highlight:false, withLabel:false, size: 4});
+                p=board.create("point", [a,fn.evaluate({x:a})], {cssClass: 'endpoint-open', fixed:true, highlight:false, withLabel:false, size: 4});
                 endpoints.push(p);
             }else{  // this is a smallerEq so we fill in blue
-                p=board.create("point", [a,l[i].items[0].evaluate({x:a})], {cssClass: 'endpoint-closed', fixed:true, highlight:false, withLabel:false, size: 4});
+                p=board.create("point", [a,fn.evaluate({x:a})], {cssClass: 'endpoint-closed', fixed:true, highlight:false, withLabel:false, size: 4});
                 endpoints.push(p);
             }
             if (ineq.conditionals[1]=="smaller"){ // this is a smaller so we fill in white, since it is an strict inequality
-                p=board.create("point", [b,l[i].items[0].evaluate({x:b})], {cssClass: 'endpoint-open', fixed:true, highlight:false, withLabel:false, size: 4});
+                p=board.create("point", [b,fn.evaluate({x:b})], {cssClass: 'endpoint-open', fixed:true, highlight:false, withLabel:false, size: 4});
                 endpoints.push(p);
             }else{ // this is a smallerEq so we fill in blue
-                p=board.create("point", [b,l[i].items[0].evaluate({x:b})], {cssClass: 'endpoint-closed', fixed:true, highlight:false, withLabel:false, size: 4});
+                p=board.create("point", [b,fn.evaluate({x:b})], {cssClass: 'endpoint-closed', fixed:true, highlight:false, withLabel:false, size: 4});
                 endpoints.push(p);
             }
         }

--- a/src/components/ui/dialogs/EditFunctionDialog.jsx
+++ b/src/components/ui/dialogs/EditFunctionDialog.jsx
@@ -455,7 +455,6 @@ const FunctionContainer = ({ index, value, instrument, onChange, onDelete, onAcc
               className={`text-input-outer ${hasError ? 'error-border error-input' : ''}`}
               aria-errormessage={hasError ? `function-${index}-error` : undefined}
             >
-              <div className="text-input-label " aria-hidden="true">f(x)=</div>
               <input
                 id={`function-${index}`}
                 type="text"
@@ -667,9 +666,6 @@ const PiecewiseFunctionContainer = ({ index, value, instrument, onChange, onDele
             className={`text-input-outer flex-1 min-w-0 ${functionHasError ? 'error-border error-input' : ''}`}
             aria-errormessage={functionHasError ? `piecewise-${index}-part-${partIndex}-function-error` : undefined}
           >
-            <div className="text-input-label" aria-hidden="true">
-              f(x)=
-            </div>
             <input
               id={`piecewise-function-${index}-part-${partIndex}-function`}
               type="text"

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -174,6 +174,34 @@ export function transformMathConstants(node) {
   })
 }
 
+// checks if txt is an assignment, for instance, y=x^2+1 or f(x)=x^2+1
+function isAssignment(txt){
+    // we first check that the input is a valid math expression
+    if (!(isValidMathParse(txt))){
+        return false;
+    }
+    const parsed = math.parse(txt); // we parse the string txt
+    return parsed.type == "AssignmentNode" || parsed.type == "FunctionAssignmentNode";
+}
+
+// returns the expression of an assignment, for instance, y=x^2+1 returns x^2+1
+// if the input is not an assignment, returns the input string
+function getAssignmentExpression(txt){
+    if (!isAssignment(txt)){
+        return txt;
+    }
+    const parsed = math.parse(txt); // we parse the string txt
+    if (parsed.type == "AssignmentNode"){
+        console.log("assignment parsed.value: ", parsed.value.toString({implicit: 'show'}));
+        return parsed.value.toString({implicit: 'show'});
+    }
+    if (parsed.type == "FunctionAssignmentNode"){
+        console.log("function assignment parsed.expr: ", parsed.expr.toString({implicit: 'show'}));
+        return parsed.expr.toString({implicit: 'show'});
+    }
+    return  "0";
+}
+
 //checks if txt describes a valid inequality: x op a, a op x with op in {<,>,<=,>=,=,==,!=}, or
 // double (chains) inequalities of the form a<=x<=b, a<x<=b, a<=x<b or a<x<b
 function isInequality(txt){
@@ -771,6 +799,7 @@ function parsePiecewise(txt){
     // it also uses implicit multiplication
     // for instance, 2 x is translated into 2*x
     function simplify(it){
+        console.log("Simplifying: ", it.toString());
         return math.simplifyConstant(it.toString()).toString({implicit: 'show'});
     }
     function items2expr(its){ //its is a list of items, each item is a pair [expr,ineq]
@@ -778,7 +807,18 @@ function parsePiecewise(txt){
             return "NaN";
         }
         const it=its[0]; // the first item
-        const fn = simplify(it.items[0]); // the expression of the function
+        let fn = it.items[0]; // the function expression
+        console.log("Parsing function: ", fn);
+        if (fn.type=="AssignmentNode"){
+            fn = fn.value; // we take the value of the assignment, that is the expression of the function
+        }
+        if (fn.type=="FunctionAssignmentNode"){
+            fn = fn.expr; // we take the expression of the function
+        }
+        console.log("Parsing function: (after check assignment) ", fn);
+
+        fn=simplify(fn); 
+        console.log("Function: ", fn.toString());
         const ineq=transformAssingnments(it.items[1]); // the inequality or equality where the function is defined, we change assignments to equalities
         let cond; // the condition of "C ? A : B"
         // inequalities of the form a op1 x op2 b are translate into a op1 x && x op2 b
@@ -912,9 +952,18 @@ export function checkMathSpell(func){
         // console.log("Single function to check: ", txt);
         errorMessage = null; // reset error message
         errorPosition = 0; // reset error position
-        if(isOneVariableFunction(txt)){
-            // jessiecode does does not understand E, e, pi, we translate them to mathjs constants
-            return [transformMathConstants(math.parse(txt)).toString({implicit: 'show'}), []];
+        if(isAssignment(txt)){
+           if(isOneVariableFunction(getAssignmentExpression(txt))){
+                // jessiecode does does not understand E, e, pi, we translate them to mathjs constants
+                console.log("Single function is valid, parsing: ", transformMathConstants(math.parse(getAssignmentExpression(txt))).toString({implicit: 'show'}));
+                return [transformMathConstants(math.parse(getAssignmentExpression(txt))).toString({implicit: 'show'}), []];
+            }
+         }else{
+           if(isOneVariableFunction(txt)){
+                // jessiecode does does not understand E, e, pi, we translate them to mathjs constants
+                console.log("Single function is valid, parsing: ", transformMathConstants(math.parse(txt)).toString({implicit: 'show'}));
+                return [transformMathConstants(math.parse(txt)).toString({implicit: 'show'}), []];
+            }
         }
         return ["0", [[errorMessage, 0]]];
     }
@@ -933,7 +982,7 @@ export function checkMathSpell(func){
             errorPosition = [i, 0];
             const fn = parts[i][0];
             const cn = parts[i][1];
-            if (!(isOneVariableFunction(fn))){
+            if (!(isOneVariableFunction(getAssignmentExpression(fn)))){
                 //errorMessage = "Invalid function format";
                 errorPosition = [i, 0];
                 //return ["0", errorMessage, errorPosition];
@@ -962,6 +1011,7 @@ export function checkMathSpell(func){
         if (compatIneq){
             const txt = functionDefPiecewiseToString(parts);
             // jessiecode does does not understand E, e, pi, we translate them to mathjs constants
+            console.log("Piecewise function is valid, parsing: ", txt);
             const expr = transformMathConstants(math.parse(txt)).toString();
             return [parsePiecewise(expr), errorList];
         }

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -953,6 +953,19 @@ export function checkMathSpell(func){
         errorMessage = null; // reset error message
         errorPosition = 0; // reset error position
         if(isAssignment(txt)){
+           const txt_parsed = math.parse(txt);
+           if (txt_parsed.type === "AssignmentNode" && txt_parsed.object.name!="y" ){
+                errorMessage = "Invalid assignment, only y=... of f(x)= is allowed";
+                return ["0", [[errorMessage, 0]]];
+           }
+           if (txt_parsed.type === "FunctionAssignmentNode" && txt_parsed.params.length!=1){
+                errorMessage = "Invalid assignment, only functions of one variable are allowed";
+                return ["0", [[errorMessage, 0]]];
+           }
+           if (txt_parsed.type === "FunctionAssignmentNode" && txt_parsed.params[0]!="x"){
+                errorMessage = "Invalid assignment, only functions in variable x are allowed";
+                return ["0", [[errorMessage, 0]]];
+           }
            if(isOneVariableFunction(getAssignmentExpression(txt))){
                 // jessiecode does does not understand E, e, pi, we translate them to mathjs constants
                 console.log("Single function is valid, parsing: ", transformMathConstants(math.parse(getAssignmentExpression(txt))).toString({implicit: 'show'}));
@@ -982,6 +995,25 @@ export function checkMathSpell(func){
             errorPosition = [i, 0];
             const fn = parts[i][0];
             const cn = parts[i][1];
+            if(isAssignment(fn)){
+            const txt_parsed = math.parse(fn);
+                if (txt_parsed.type === "AssignmentNode" && txt_parsed.object.name!="y" ){
+                        errorMessage = "Invalid assignment, only y=... of f(x)= is allowed";
+                        errorPosition = [i, 0];
+                        errorList.push([errorMessage, errorPosition]);
+                }
+                if (txt_parsed.type === "FunctionAssignmentNode" && txt_parsed.params.length!=1){
+                        errorMessage = "Invalid assignment, only functions of one variable are allowed";
+                        errorPosition = [i, 0];
+                        errorList.push([errorMessage, errorPosition]);
+                }
+                if (txt_parsed.type === "FunctionAssignmentNode" && txt_parsed.params[0]!="x"){
+                        errorMessage = "Invalid assignment, only functions in variable x are allowed";
+                        errorPosition = [i, 0];
+                        errorList.push([errorMessage, errorPosition]);
+                }
+            }
+
             if (!(isOneVariableFunction(getAssignmentExpression(fn)))){
                 //errorMessage = "Invalid function format";
                 errorPosition = [i, 0];


### PR DESCRIPTION
Now, "f(x)=" does not appear in the edit dialog and the user may enter the expression of the function "expr" or "f(x)=expr" or "y=expr".